### PR TITLE
Update use of coredis to use 3.x API

### DIFF
--- a/falcon_caching/async_backends/__init__.py
+++ b/falcon_caching/async_backends/__init__.py
@@ -49,8 +49,8 @@ def filesystem(config, args, kwargs):
 
 def redis(config, args, kwargs):
     try:
-        from coredis import Redis
-        redis_from_url = Redis.from_url
+        from coredis import Redis as _Redis
+        redis_from_url = _Redis.from_url
     except ImportError:
         raise RuntimeError("no coredis module found")
 

--- a/falcon_caching/async_backends/__init__.py
+++ b/falcon_caching/async_backends/__init__.py
@@ -49,8 +49,8 @@ def filesystem(config, args, kwargs):
 
 def redis(config, args, kwargs):
     try:
-        from coredis import StrictRedis
-        redis_from_url = StrictRedis.from_url
+        from coredis import Redis
+        redis_from_url = Redis.from_url
     except ImportError:
         raise RuntimeError("no coredis module found")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ Documentation = "https://falcon-caching.readthedocs.io/en/latest/"
 [tool.flit.metadata.requires-extra]
 test = [
     "aiofiles",
-    "coredis",
+    "coredis>=3.0.0",
     "emcache",
     "flit",
     "pylibmc",


### PR DESCRIPTION
# Description
There are a bunch of breaking api changes between coredis 2.x (backward compatible with aredis) and coredis 3.x. I won't be maintaining the 2.x branch for much longer and have updated the limits library to use 3.x as well.

## References
- [Major changes in 3.x](https://coredis.readthedocs.io/en/stable/release_notes.html#v3-0-0)

## Misc Notes
- Python 3.7 support is dropped
