### PR TITLE
Feature/caching by query param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Pipfile.lock
 todos.txt
 tests/sentinel.conf
 bin/
+._*

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is a port of the popular [Flask-Caching](https://github.com/sh4nks/flask-cach
 The library aims to be compatible with CPython 3.7+ and PyPy 3.5+.
 
 You can use this library both with a sync (WSGI) or an async (ASGI) app,
-by using the matching cache object (`Cache` or `AsyncCache`). 
+by using the matching cache object (`Cache` or `AsyncCache`).
 
 
 ## Documentation
@@ -90,7 +90,7 @@ class ThingsResource:
         pass
 ```
 
-> **NOTE:**  
+> **NOTE:**
 > Be careful with the order of middlewares. The `cache.middleware` will
 short-circuit any further processing if a cached version of that resource is found.
 It will skip any remaining `process_request` and `process_resource` methods,
@@ -107,8 +107,8 @@ For the development environment we use `Pipenv` and for packaging we use `Flit`.
 
 ### Documentation
 
-The documentation is built via Sphinx following the 
-[Google docstring style](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html#example-google) 
+The documentation is built via Sphinx following the
+[Google docstring style](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html#example-google)
 and hosted on [Read the Docs](https://falcon-caching.readthedocs.io/en/latest/).
 
 To review the documentation locally before committing:
@@ -128,7 +128,7 @@ the memcached source to compile, so you will need to install libmemcached-dev fi
 $ sudo apt-get install libmemcached-dev
 ```
 
-You will also need Memcached, Redis and Redis Sentinel to be installed 
+You will also need Memcached, Redis and Redis Sentinel to be installed
 to be able to test against those locally:
 ```
 $ sudo apt-get install memcached redis-server redis-sentinel
@@ -139,7 +139,7 @@ You will also need Python 3.7-3.10 and PyPy3 and its source package installed to
 
 We do use type hinting and run MyPy on those, but unfortunately MyPy currently breaks
 the PyPy tests due to the `typed-ast` package's "bug" (see
-https://github.com/python/typed_ast/issues/97). Also with Pipenv you can't 
+https://github.com/python/typed_ast/issues/97). Also with Pipenv you can't
 have a second Pipfile. This is why for now we don't have `mypy` listed as a dev package
 in the Pipfile.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can find the documentation of this library on [Read the Docs](https://falcon
 
 
 Quick example 1  - WSGI, e.g. sync:
-```
+```python
 import falcon
 from falcon_caching import Cache
 
@@ -53,7 +53,7 @@ app.add_route('/things', things)
 
 
 Quick example 2 - ASGI, e.g. async:
-```
+```python
 import falcon.asgi
 from falcon_caching import AsyncCache
 
@@ -79,7 +79,7 @@ app.add_route('/things', things)
 ```
 
 Alternatively you could cache the whole resource (sync or async):
-```
+```python
 # mark the whole resource - all its 'on_' methods as cached
 @cache.cached(timeout=600)
 class ThingsResource:
@@ -96,10 +96,45 @@ short-circuit any further processing if a cached version of that resource is fou
 It will skip any remaining `process_request` and `process_resource` methods,
 as well as the `responder` method that the request would have been routed to.
 However, any `process_response` middleware methods will still be called.
->
+
 > This is why it is suggested that you add the `cache.middleware` **following** any
 authentication / authorization middlewares to avoid unauthorized access of records
 served from the cache.
+
+## Query Parameter Caching
+
+The library now supports optional caching by query parameters. This can be configured globally or per-endpoint.
+
+### Global Configuration
+
+```python
+cache = Cache(config={
+    'CACHE_TYPE': 'simple',
+    'CACHE_EVICTION_STRATEGY': 'time-based',
+    'CACHE_INCLUDE_QUERY_PARAMS': True  # Enable query parameter caching globally
+})
+```
+
+### Per-Endpoint Configuration
+
+You can override the global setting for specific endpoints using the decorator:
+
+```python
+# Enable for specific endpoint when disabled globally
+class MyResource:
+    @cache.cached(timeout=60, include_query_params=True)
+    def on_get(self, req, resp):
+        param_value = req.get_param('name')
+        resp.text = f'Hello {param_value}'
+
+# Disable for specific endpoint when enabled globally
+class AnotherResource:
+    @cache.cached(timeout=60, include_query_params=False)
+    def on_get(self, req, resp):
+        resp.text = 'Hello World'
+```
+
+When enabled, query parameters are normalized (sorted) to avoid cache misses due to parameter reordering.
 
 ## Development
 

--- a/falcon_caching/async_backends/memcache.py
+++ b/falcon_caching/async_backends/memcache.py
@@ -101,8 +101,10 @@ class MemcachedCache(BaseCache):
 
     def _normalize_timeout(self, timeout):
         timeout = BaseCache._normalize_timeout(self, timeout)
-        if timeout > 0:
-            timeout = int(time()) + timeout
+        # despite its documentation, emcache definitely interprets values smaller than 30 days (in seconds) as relative delta
+        # for values greater than 30 days, it's bizzarely inconsistent. See tests/async_tests/test_emcache_exptime.py for details
+        if timeout > 30 * 24 * 3600:
+            timeout = 0
 
         return timeout
 

--- a/falcon_caching/async_cache.py
+++ b/falcon_caching/async_cache.py
@@ -167,6 +167,7 @@ class AsyncCache:
         config.setdefault("CACHE_EVICTION_STRATEGY", CacheEvictionStrategy.time_based)
         config.setdefault("CACHE_CONTENT_TYPE_JSON_ONLY", False)
         config.setdefault("CACHE_DEBUG", False)
+        config.setdefault("CACHE_INCLUDE_QUERY_PARAMS", False)
 
         self.config = config
 
@@ -193,9 +194,15 @@ class AsyncCache:
         return Middleware(self.cache, self.config)
 
     # @staticmethod
-    def cached(self, timeout: int):
+    def cached(self, timeout: int, include_query_params: bool = None):
         """ This is the decorator used to decorate a resource class or the requested
         method of the resource class
+
+        Args:
+            timeout: Cache timeout in seconds
+            include_query_params: Whether to include query parameters in cache key.
+                                 If None, uses global CACHE_INCLUDE_QUERY_PARAMS setting.
+                                 If True/False, overrides global setting for this endpoint.
         """
         def wrap1(class_or_method, *args):
             # is this about decorating a class or a given method?
@@ -213,6 +220,9 @@ class AsyncCache:
                     await class_or_method(cls, req, resp, *args, **kwargs)
                     req.context.cache = True
                     req.context.cache_timeout = timeout
+                    # Set query parameter caching preference if specified in decorator
+                    if include_query_params is not None:
+                        req.context.cache_include_query_params = include_query_params
 
                 return cache_wrap
 

--- a/falcon_caching/async_middleware.py
+++ b/falcon_caching/async_middleware.py
@@ -4,6 +4,7 @@ import logging
 import re
 import msgpack
 from typing import TYPE_CHECKING, Any, Dict, Tuple
+from urllib.parse import parse_qsl, urlencode
 
 if TYPE_CHECKING:
     from falcon_caching.async_cache import AsyncCache
@@ -139,9 +140,11 @@ class Middleware:
 
             await self.cache.set(key, value, timeout=timeout)
 
-    @staticmethod
-    async def generate_cache_key(req, method: str = None) -> str:
-        """ Generate the cache key from the request using the path and the method """
+    async def generate_cache_key(self, req, method: str = None) -> str:
+        """
+        Generate the cache key from the request using the path and the method. A manually specified method
+        is useful for evicting previously cached responses when a resource has been updated via PUT, etc.
+        """
 
         path = req.path
         if path.endswith('/'):
@@ -150,7 +153,21 @@ class Middleware:
         if not method:
             method = req.method
 
-        return f'{path}:{method.upper()}'
+        # Check if query parameters should be included in cache key
+        # This can be configured globally via CACHE_INCLUDE_QUERY_PARAMS or
+        # overridden per endpoint via decorator and injected into req.context
+        if req.context.get('cache_include_query_params') is None:
+            include_query_params = self.cache_config['CACHE_INCLUDE_QUERY_PARAMS']
+        else:
+            include_query_params = req.context.get('cache_include_query_params')
+
+        if include_query_params and req.query_string:
+            # Normalize query parameters by sorting them alphabetically
+            query_params = parse_qsl(req.query_string)
+            normalized_query_string = urlencode(sorted(query_params))
+            return f'{path}:{method.upper()}?{normalized_query_string}'
+        else:
+            return f'{path}:{method.upper()}'
 
     async def serialize(self, req, resp, resource) -> bytes:
         """ Serializes the response, so it can be cached.

--- a/falcon_caching/cache.py
+++ b/falcon_caching/cache.py
@@ -167,6 +167,7 @@ class Cache:
         config.setdefault("CACHE_EVICTION_STRATEGY", CacheEvictionStrategy.time_based)
         config.setdefault("CACHE_CONTENT_TYPE_JSON_ONLY", False)
         config.setdefault("CACHE_DEBUG", False)
+        config.setdefault("CACHE_INCLUDE_QUERY_PARAMS", False)
 
         self.config = config
 
@@ -193,9 +194,15 @@ class Cache:
         return Middleware(self.cache, self.config)
 
     @staticmethod
-    def cached(timeout: int):
+    def cached(timeout: int, include_query_params: bool = None):
         """ This is the decorator used to decorate a resource class or the requested
         method of the resource class
+
+        Args:
+            timeout: Cache timeout in seconds
+            include_query_params: Whether to include query parameters in cache key.
+                                 If None, uses global CACHE_INCLUDE_QUERY_PARAMS setting.
+                                 If True/False, overrides global setting for this endpoint.
         """
         def wrap1(class_or_method, *args):
             # is this about decorating a class or a given method?
@@ -213,6 +220,9 @@ class Cache:
                     class_or_method(cls, req, resp, *args, **kwargs)
                     req.context.cache = True
                     req.context.cache_timeout = timeout
+                    # Set query parameter caching preference if specified in decorator
+                    if include_query_params is not None:
+                        req.context.cache_include_query_params = include_query_params
 
                 return cache_wrap
 

--- a/falcon_caching/middleware.py
+++ b/falcon_caching/middleware.py
@@ -4,6 +4,7 @@ import logging
 import re
 import msgpack
 from typing import TYPE_CHECKING, Any, Dict, Tuple
+from urllib.parse import parse_qsl, urlencode
 
 if TYPE_CHECKING:
     from falcon_caching.cache import Cache
@@ -138,9 +139,11 @@ class Middleware:
 
             self.cache.set(key, value, timeout=timeout)
 
-    @staticmethod
-    def generate_cache_key(req, method: str = None) -> str:
-        """ Generate the cache key from the request using the path and the method """
+    def generate_cache_key(self, req, method: str = None) -> str:
+        """
+        Generate the cache key from the request using the path and the method. A manually specified method
+        is useful for evicting previously cached responses when a resource has been updated via PUT, etc.
+        """
 
         path = req.path
         if path.endswith('/'):
@@ -149,7 +152,21 @@ class Middleware:
         if not method:
             method = req.method
 
-        return f'{path}:{method.upper()}'
+        # Check if query parameters should be included in cache key
+        # This can be configured globally via CACHE_INCLUDE_QUERY_PARAMS or
+        # overridden per endpoint via decorator and injected into req.context
+        if req.context.get('cache_include_query_params') is None:
+            include_query_params = self.cache_config['CACHE_INCLUDE_QUERY_PARAMS']
+        else:
+            include_query_params = req.context.get('cache_include_query_params')
+
+        if include_query_params and req.query_string:
+            # Normalize query parameters by sorting them alphabetically
+            query_params = parse_qsl(req.query_string)
+            normalized_query_string = urlencode(sorted(query_params))
+            return f'{path}:{method.upper()}?{normalized_query_string}'
+        else:
+            return f'{path}:{method.upper()}'
 
     def serialize(self, req, resp, resource) -> bytes:
         """ Serializes the response, so it can be cached.

--- a/tests/async_tests/test_app.py
+++ b/tests/async_tests/test_app.py
@@ -318,3 +318,33 @@ def test_caching_content_type_json_only(tmp_path, async_cache_type, eviction_str
         result2 = client.simulate_get('/randrange_cached3')
         assert result1.json['num'] == result2.json['num']
         assert result2.headers['Content-Type'] == 'application/json'
+
+
+def test_query_parameter_handling(async_client):
+    """Test that query parameters are properly included/excluded based on configuration"""
+    # Check the query parameter configuration using the utility function
+    cache = get_cache(async_client.app)
+    include_query_params = cache.cache_config.get('CACHE_INCLUDE_QUERY_PARAMS', False)
+
+    # Clear cache for the endpoint
+    asyncio.get_event_loop().run_until_complete(
+        async_client.app._middleware[1][0].__self__.cache.delete(f"/randrange_cached:GET"))
+
+    # Test with query parameters
+    result1 = async_client.simulate_get('/randrange_cached?sort=asc&filter=active')
+
+    # Test without query parameters
+    result2 = async_client.simulate_get('/randrange_cached')
+
+    # Test with query parameters in a different order
+    result3 = async_client.simulate_get('/randrange_cached?filter=active&sort=asc')
+
+    if include_query_params:
+        # Query params should be included and sorted
+        # Different query params should result in different cache entries
+        assert result1.json['num'] != result2.json['num']
+        assert result1.json['num'] == result3.json['num']
+    else:
+        # Query params should be excluded
+        # Same cache key should result in same cached value
+        assert result1.json['num'] == result2.json['num'] == result3.json['num']

--- a/tests/async_tests/test_emcache_exptime.py
+++ b/tests/async_tests/test_emcache_exptime.py
@@ -1,0 +1,54 @@
+""" Test the raw emcache library exptime behavior.
+
+Contrary to the documentation of emcache, the exptime argument seems to be generally interpreted
+as a relative time delta. It also seems that this delta cannot be larger than 30 days (in seconds),
+otherwise, conflicting behavior emerges, possibly due to memcached itself.
+
+This test is just meant to show that a short exptime is definitely interpreted as a delta in seconds.
+"""
+import pytest
+import asyncio
+
+
+@pytest.mark.asyncio
+async def test_emcache_exptime_behavior():
+    """Test emcache exptime parameter behavior"""
+
+    try:
+        import emcache
+    except ImportError:
+        pytest.skip("emcache library not installed")
+
+    try:
+        client = await emcache.create_client(
+            node_addresses=[emcache.MemcachedHostAddress("127.0.0.1", 11211)],
+            timeout=1.0
+        )
+    except Exception:
+        pytest.skip("Could not connect to memcached server")
+
+    # Test 1: Small relative timeout
+    await client.set(b"test1", b"value1", exptime=1)
+    result = await client.get(b"test1")
+    assert result is not None, "Should set successfully with relative timeout"
+
+    await asyncio.sleep(2)
+    result = await client.get(b"test1")
+    assert result is None, "Should expire after relative timeout"
+
+    # Test 2: Small absolute timeout (this case should succeed but fails)
+    # import time
+    # await client.set(b"test1", b"value1", exptime=int(time.time()) + 1)
+    # result = await client.get(b"test1")
+    # assert result is not None, "Should set successfully with now+1s timeout"
+
+    # await asyncio.sleep(2)
+    # result = await client.get(b"test1")
+    # assert result is None, "Should expire after 1s"
+
+    # Test 3: Absolute time in the past (30 days + 1 second)
+    await client.set(b"test1", b"value1", exptime=300 * 24 * 3600 + 1)
+    result = await client.get(b"test1")
+    assert result is None, "Should not succeed with a expiration time in the past"
+
+    await client.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,12 @@ CACHE_BUSTING_METHODS = [
     'DELETE'
 ]
 
+# including query parameters or not
+QUERY_PARAM_CONFIGS = [
+    {'CACHE_INCLUDE_QUERY_PARAMS': True},
+    {'CACHE_INCLUDE_QUERY_PARAMS': False},
+]
+
 # we want to test the pruning, so we set the threshold low
 # instead of the default 500
 CACHE_THRESHOLD = 5
@@ -94,7 +100,7 @@ def pytest_sessionfinish(session, exitstatus):
 
 # parametrized fixture to create caches with different types (eg backends)
 @pytest.fixture(params=CACHE_TYPES)
-def caches(request, tmp_path):
+def caches(request, tmp_path, query_param_config):
     """ Time-based cache parametrized to generate a cache
     for each cache_type (eg backend)
     """
@@ -129,7 +135,8 @@ def caches(request, tmp_path):
                     'CACHE_TYPE': request.param,
                     'CACHE_THRESHOLD': CACHE_THRESHOLD,
                     'CACHE_DIR': tmp_path if request.param == 'filesystem' else None,
-                    'CACHE_REDIS_PORT': REDIS_PORT
+                    'CACHE_REDIS_PORT': REDIS_PORT,
+                    **query_param_config, # this unpacks to either {'CACHE_INCLUDE_QUERY_PARAMS': True} or {...: False}
                 }
             )
         for eviction_strategy in EVICTION_STRATEGIES
@@ -139,7 +146,7 @@ def caches(request, tmp_path):
 
 # parametrized fixture to create caches with different types (eg backends)
 @pytest.fixture(params=ASYNC_CACHE_TYPES)
-def async_caches(request, tmp_path):
+def async_caches(request, tmp_path, query_param_config):
     """Time-based cache parametrized to generate a cache
     for each cache_type (eg backend)
     """
@@ -165,7 +172,8 @@ def async_caches(request, tmp_path):
                     'CACHE_TYPE': request.param,
                     'CACHE_THRESHOLD': CACHE_THRESHOLD,
                     'CACHE_DIR': tmp_path if request.param == 'filesystem' else None,
-                    'CACHE_REDIS_PORT': REDIS_PORT
+                    'CACHE_REDIS_PORT': REDIS_PORT,
+                    **query_param_config,
                 }
             )
         for eviction_strategy in EVICTION_STRATEGIES
@@ -432,4 +440,12 @@ def async_client(async_app):
     ids=[method.__name__ for method in SUPPORTED_HASH_FUNCTIONS],
 )
 def hash_method(request):
+    return request.param
+
+@pytest.fixture(
+    params=QUERY_PARAM_CONFIGS,
+    ids=['use-query-params', 'ignore-query-params']
+)
+def query_param_config(request):
+    """Provides configurations for whether query parameters used for caching keys"""
     return request.param

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -298,8 +298,34 @@ def test_caching_content_type_json_only(tmp_path, cache_type, eviction_strategy,
         result1 = client.simulate_get('/randrange_cached')
         assert result1.headers['Content-Type'] == 'mycustom/verycustom'
 
-        # the second call returns it from cache - but as the content-type
+         # the second call returns it from cache - but as the content-type
         # is NOT cached, it will return the default 'application/json' type
         result2 = client.simulate_get('/randrange_cached')
         assert result1.json['num'] == result2.json['num']
         assert result2.headers['Content-Type'] == 'application/json'
+
+
+def test_query_parameter_handling(client):
+    """Test that query parameters are properly included/excluded based on configuration"""
+    # Check the query parameter configuration using the utility function
+    cache = get_cache(client.app)
+    include_query_params = cache.cache_config.get('CACHE_INCLUDE_QUERY_PARAMS', False)
+
+    # Test with query parameters
+    result1 = client.simulate_get('/randrange_cached?sort=asc&filter=active')
+
+    # Test without query parameters
+    result2 = client.simulate_get('/randrange_cached')
+
+    # Test with query parameters in a different order
+    result3 = client.simulate_get('/randrange_cached?filter=active&sort=asc')
+
+    if include_query_params:
+        # Query params should be included and sorted
+        # Different query params should result in different cache entries
+        assert result1.json['num'] != result2.json['num']
+        assert result1.json['num'] == result3.json['num']
+    else:
+        # Query params should be excluded
+        # Same cache key should result in same cached value
+        assert result1.json['num'] == result2.json['num'] == result3.json['num']


### PR DESCRIPTION
This pull request introduces query parameter caching support and fixes a timeout handling issue in the async memcached backend due to apparent discrepancy between emcache's documentation and its actual behavior.

### Key Changes:

1. Query Parameter Caching Feature:
   - Added CACHE_INCLUDE_QUERY_PARAMS configuration option (default: False) - should we make this True by default?
   - Added include_query_params parameter to @cache.cached() decorator
   - When enabled, query parameters are included in cache keys and normalized (sorted alphabetically)
   - Can be configured globally or overridden per-endpoint (both ways: False globally enabled per-endpoint or True globally and disabled per-endpoint)

2. Async memcached backend timeout fix:
   - Added test file to demonstrate emcached's `exptime` parameter behavior deviates from its documentation. It claims to use absolute timestamp, but it is treated as relative delta seconds.
   - Fixed timeout handling in falcon_caching/async_backends/memcache.py as a result.
   - Changed behavior to treat values > 30 days as invalid (setting to 0)
   - Tests that previously failed now pass after this change.

3. Documentation Updates:
   - Added Query Parameter Caching section to README
   - Fixed code formatting in examples
   - Minor formatting improvements
 
4. Test Coverage:
   - Added query parameter handling (on or off) as a fixture so that all tests cover the use of query parameters.
   - Tests cover both sync and async implementations