### PR TITLE
bump version to 1.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.2.0
 commit = False
 tag = True
 sign_tags = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ copyright = '2022, Zoltan Fedor'
 author = 'Zoltan Fedor'
 
 # The full version, including alpha/beta/rc tags
-release = '1.1.0'
+release = '1.2.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Welcome to Falcon-Caching's documentation!
 ==========================================
 
-Version: 1.1.0
+Version: 1.2.0
 
 Falcon-Caching adds cache support to the
 `Falcon web framework <https://github.com/falconry/falcon>`_.

--- a/falcon_caching/__init__.py
+++ b/falcon_caching/__init__.py
@@ -1,7 +1,7 @@
 """ Falcon-Caching - a caching module for the Falcon web framework
 """
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 from falcon_caching.cache import Cache
 from falcon_caching.async_cache import AsyncCache


### PR DESCRIPTION
The version is bumped to 1.2.0 to expose the support for caching by query parameters. 